### PR TITLE
差分表示をできるように

### DIFF
--- a/packages/frontend/src/components/MkNoteDetailed.vue
+++ b/packages/frontend/src/components/MkNoteDetailed.vue
@@ -184,8 +184,8 @@ SPDX-License-Identifier: AGPL-3.0-only
 						</div>
 						<div>
 							<CodeDiff
-								:old-string="appearNote.noteEditHistory[index - 1] || appearNote.noteEditHistory[0]"
-								:new-string="text"
+								:oldString="appearNote.noteEditHistory[index - 1] || ''"
+								:newString="text"
 								:trim="true"
 								:hideHeader="true"
 								diffStyle="char"

--- a/packages/frontend/src/components/MkNoteDetailed.vue
+++ b/packages/frontend/src/components/MkNoteDetailed.vue
@@ -176,16 +176,20 @@ SPDX-License-Identifier: AGPL-3.0-only
 		</div>
 		<div v-else-if="tab === 'history'" :class="$style.tab_history">
 			<div style="display: grid;">
-				<div v-for="text in appearNote.noteEditHistory" :class="$style.historyRoot" :key="text">
+				<div v-for="(text, index) in appearNote.noteEditHistory" :key="text" :class="$style.historyRoot">
 					<MkAvatar :class="$style.avatar" :user="appearNote.user" link preview/>
 					<div :class="$style.historyMain">
 						<div :class="$style.historyHeader">
 							<MkUserName :user="appearNote.user" :nowrap="true"/>
 						</div>
 						<div>
-							<div>
-								<Mfm :text="text.trim()" :author="appearNote.user" :i="$i"/>
-							</div>
+							<CodeDiff
+								:old-string="appearNote.noteEditHistory[index - 1] || appearNote.noteEditHistory[0]"
+								:new-string="text"
+								:trim="true"
+								:hideHeader="true"
+								diffStyle="char"
+							/>
 						</div>
 					</div>
 				</div>
@@ -205,7 +209,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 </template>
 
 <script lang="ts" setup>
-import { computed, inject, onMounted, ref, shallowRef } from 'vue';
+import { computed, inject, onMounted, onUnmounted, ref, shallowRef } from 'vue';
 import * as mfm from 'mfm-js';
 import * as Misskey from 'misskey-js';
 import MkNoteSub from '@/components/MkNoteSub.vue';
@@ -240,6 +244,7 @@ import MkUserCardMini from '@/components/MkUserCardMini.vue';
 import MkPagination, { Paging } from '@/components/MkPagination.vue';
 import MkReactionIcon from '@/components/MkReactionIcon.vue';
 import MkButton from '@/components/MkButton.vue';
+import { CodeDiff } from 'v-code-diff';
 
 const props = defineProps<{
 	note: Misskey.entities.Note;

--- a/packages/misskey-js/etc/misskey-js.api.md
+++ b/packages/misskey-js/etc/misskey-js.api.md
@@ -2644,6 +2644,7 @@ type Note = {
     id: ID;
     createdAt: DateString;
     updatedAt?: DateString | null;
+    noteEditHistory: string[];
     text: string | null;
     cw: string | null;
     user: User;
@@ -2983,7 +2984,7 @@ type UserSorting = '+follower' | '-follower' | '+createdAt' | '-createdAt' | '+u
 // src/api.types.ts:18:25 - (ae-forgotten-export) The symbol "NoParams" needs to be exported by the entry point index.d.ts
 // src/api.types.ts:631:18 - (ae-forgotten-export) The symbol "ShowUserReq" needs to be exported by the entry point index.d.ts
 // src/entities.ts:107:2 - (ae-forgotten-export) The symbol "notificationTypes_2" needs to be exported by the entry point index.d.ts
-// src/entities.ts:595:2 - (ae-forgotten-export) The symbol "ModerationLogPayloads" needs to be exported by the entry point index.d.ts
+// src/entities.ts:596:2 - (ae-forgotten-export) The symbol "ModerationLogPayloads" needs to be exported by the entry point index.d.ts
 // src/streaming.types.ts:33:4 - (ae-forgotten-export) The symbol "FIXME" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)


### PR DESCRIPTION
## What
misskey-dev/misskey PR [#11938](https://github.com/misskey-dev/misskey/pull/11938) の改善案
編集履歴の差分表示を可能にする。

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
