### PR TITLE
Applying PGroonga to Misskey

### DIFF
--- a/packages/backend/migration/1703417579791-pgroonga.js
+++ b/packages/backend/migration/1703417579791-pgroonga.js
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and other misskey contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export class Pgroonga1703417579791 {
+    name = 'Pgroonga1703417579791'
+
+    async up(queryRunner) {
+			await queryRunner.query(`CREATE INDEX "IDX_f27f5d88941e57442be75ba9c8" ON "note" USING "pgroonga" ("text")`);
+			await queryRunner.query(`CREATE INDEX "IDX_065d4d8f3b5adb4a08841eae3c" ON "user" USING "pgroonga" ("name" pgroonga_varchar_full_text_search_ops_v2)`);
+			await queryRunner.query(`CREATE INDEX "IDX_fcb770976ff8240af5799e3ffc" ON "user_profile" USING "pgroonga" ("description" pgroonga_varchar_full_text_search_ops_v2) `);
+
+    }
+
+    async down(queryRunner) {
+			await queryRunner.query(`DROP INDEX "public"."IDX_f27f5d88941e57442be75ba9c8"`);
+			await queryRunner.query(`DROP INDEX "public"."IDX_065d4d8f3b5adb4a08841eae3c"`);
+			await queryRunner.query(`DROP INDEX "public"."IDX_fcb770976ff8240af5799e3ffc"`);
+		}
+}

--- a/packages/backend/src/core/SearchService.ts
+++ b/packages/backend/src/core/SearchService.ts
@@ -215,7 +215,7 @@ export class SearchService {
 			}
 
 			query
-				.andWhere('note.text ILIKE :q', { q: `%${ sqlLikeEscape(q) }%` })
+				.andWhere('note.text &@~ :q', { q: sqlLikeEscape(q) })
 				.innerJoinAndSelect('note.user', 'user')
 				.leftJoinAndSelect('note.reply', 'reply')
 				.leftJoinAndSelect('note.renote', 'renote')

--- a/packages/backend/src/models/Note.ts
+++ b/packages/backend/src/models/Note.ts
@@ -53,6 +53,7 @@ export class MiNote {
 	public threadId: string | null;
 
 	// TODO: varcharにしたい
+	@Index() // USING pgroonga
 	@Column('text', {
 		nullable: true,
 	})

--- a/packages/backend/src/models/User.ts
+++ b/packages/backend/src/models/User.ts
@@ -49,6 +49,7 @@ export class MiUser {
 	})
 	public usernameLower: string;
 
+	@Index() // USING pgroonga pgroonga_varchar_full_text_search_ops_v2
 	@Column('varchar', {
 		length: 128, nullable: true,
 		comment: 'The name of the User.',

--- a/packages/backend/src/models/UserProfile.ts
+++ b/packages/backend/src/models/UserProfile.ts
@@ -36,6 +36,7 @@ export class MiUserProfile {
 	})
 	public birthday: string | null;
 
+	@Index() // USING pgroonga pgroonga_varchar_full_text_search_ops_v2
 	@Column('varchar', {
 		length: 2048, nullable: true,
 		comment: 'The description (bio) of the User.',

--- a/packages/backend/src/server/api/endpoints/notes/search.ts
+++ b/packages/backend/src/server/api/endpoints/notes/search.ts
@@ -31,6 +31,11 @@ export const meta = {
 			code: 'UNAVAILABLE',
 			id: '0b44998d-77aa-4427-80d0-d2c9b8523011',
 		},
+		noSuchNote: {
+			message: 'Query is empty.',
+			code: 'QUERY_IS_EMPTY',
+			id: 'd0410b51-f409-4667-8118-cfe999e453c3',
+		},
 	},
 } as const;
 
@@ -62,6 +67,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 		private roleService: RoleService,
 	) {
 		super(meta, paramDef, async (ps, me) => {
+			if (ps.query.trim().length === 0) throw new ApiError(meta.errors.noSuchNote);
 			const policies = await this.roleService.getUserPolicies(me ? me.id : null);
 			if (!policies.canSearchNotes) {
 				throw new ApiError(meta.errors.unavailable);

--- a/packages/backend/src/server/api/endpoints/users/search.ts
+++ b/packages/backend/src/server/api/endpoints/users/search.ts
@@ -85,11 +85,11 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 			} else {
 				const nameQuery = this.usersRepository.createQueryBuilder('user')
 					.where(new Brackets(qb => {
-						qb.where('user.name ILIKE :query', { query: '%' + sqlLikeEscape(ps.query) + '%' });
+						qb.where('user.name &@~ :query', { query: ps.query });
 
 						// Also search username if it qualifies as username
-						if (this.userEntityService.validateLocalUsername(ps.query)) {
-							qb.orWhere('user.usernameLower LIKE :username', { username: '%' + sqlLikeEscape(ps.query.toLowerCase()) + '%' });
+						if (userEntityService.validateLocalUsername(ps.query)) {
+							qb.orWhere('user.usernameLower LIKE :username', { username: ps.query.toLowerCase() + '%' });
 						}
 					}))
 					.andWhere(new Brackets(qb => {
@@ -114,7 +114,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				if (users.length < ps.limit) {
 					const profQuery = this.userProfilesRepository.createQueryBuilder('prof')
 						.select('prof.userId')
-						.where('prof.description ILIKE :query', { query: '%' + sqlLikeEscape(ps.query) + '%' });
+						.where('prof.description &@~ :query', { query: ps.query });
 
 					if (ps.origin === 'local') {
 						profQuery.andWhere('prof.userHost IS NULL');


### PR DESCRIPTION
日本語:

# MisskeyでPGroongaを使えるように

## PGroongaとその依存関係をインストール

### Ubuntu/Debian向け

[この](https://pgroonga.github.io/ja/install/)ドキュメントにしたがってインストールしてください

また必ず使っているPostgreSQLサーバーのバージョンに合わせたパッケージをインストールしてください

### Arch Linux向け

AUR経由でインストールできます

https://aur.archlinux.org/packages/pgroonga

## PGroongaを有効化

psqlを使ってPostgreSQLサーバーに接続してMisskeyで使っているデーターベースに入ります

そしてPGroongaを有効化します

`CREATE EXTENSION pgroonga;`

## Misskey側での変更

PGroongaのクエリーを使う変更をしたMisskeyに変更します

下のコマンドでリモートを追加してチェックアウトします

```
git remote add grapeapple https://github.com/grapeapple0/misskey.git
git fetch grapeapple/pgroonga-patched
git checkout grapeapple/pgroonga-patched
```

あとは(必要ならば`pnpm install`も)`pnpm build`、`pnpm migrate`を実行します

English:
# Applying PGroonga to Misskey

## Install PGroonga and it dependencies

### For Ubuntu/debian

Install these packages with following [this](https://pgroonga.github.io/install/) docs.

Important: Please install Pgroonga package for your PostgreSQL version.

### For Arch Linux

Install [this](https://aur.archlinux.org/packages/pgroonga) AUR package.

If uses yay, can be install it with this command.

`yay -S pgroonga`

## Enable PGroonga extension

Connect using a psql client in your misskey database and run this command

`CREATE EXTENSION pgroonga;`

## Apply code for Misskey

Add this remote and checkout the branch of applying PGroonga query.

```
git remote add grapeapple https://github.com/grapeapple0/misskey.git
git fetch grapeapple/pgroonga-patched
git checkout grapeapple/pgroonga-patched
```

And, run `pnpm build` and `pnpm migrate`